### PR TITLE
Change the location of the Common Budget Issue function before and after the Merge

### DIFF
--- a/consensus/beacon/consensus.go
+++ b/consensus/beacon/consensus.go
@@ -323,18 +323,19 @@ func (beacon *Beacon) Prepare(chain consensus.ChainHeaderReader, header *types.H
 
 // Finalize implements consensus.Engine, setting the final state on the header
 func (beacon *Beacon) Finalize(chain consensus.ChainHeaderReader, header *types.Header, state *state.StateDB, txs []*types.Transaction, uncles []*types.Header) {
-	if chain.Config().IsBosagora(header.Number) {
-		if header.Number.Cmp(&chain.Config().Bosagora.LastCommonsBudgetRewardBlock) < 0 {
-			state.AddBalance(chain.Config().Bosagora.CommonsBudget, &chain.Config().Bosagora.CommonsBudgetReward)
-		}
-	}
-
 	// Finalize is different with Prepare, it can be used in both block generation
 	// and verification. So determine the consensus rules by header type.
 	if !beacon.IsPoSHeader(header) {
 		beacon.ethone.Finalize(chain, header, state, txs, uncles)
 		return
 	}
+
+	if chain.Config().IsBosagora(header.Number) {
+		if header.Number.Cmp(&chain.Config().Bosagora.LastCommonsBudgetRewardBlock) < 0 {
+			state.AddBalance(chain.Config().Bosagora.CommonsBudget, &chain.Config().Bosagora.CommonsBudgetReward)
+		}
+	}
+
 	// The block reward is no longer handled here. It's done by the
 	// external consensus engine.
 	header.Root = state.IntermediateRoot(true)

--- a/consensus/beacon/consensus.go
+++ b/consensus/beacon/consensus.go
@@ -323,6 +323,12 @@ func (beacon *Beacon) Prepare(chain consensus.ChainHeaderReader, header *types.H
 
 // Finalize implements consensus.Engine, setting the final state on the header
 func (beacon *Beacon) Finalize(chain consensus.ChainHeaderReader, header *types.Header, state *state.StateDB, txs []*types.Transaction, uncles []*types.Header) {
+	if chain.Config().IsBosagora(header.Number) {
+		if header.Number.Cmp(&chain.Config().Bosagora.LastCommonsBudgetRewardBlock) < 0 {
+			state.AddBalance(chain.Config().Bosagora.CommonsBudget, &chain.Config().Bosagora.CommonsBudgetReward)
+		}
+	}
+
 	// Finalize is different with Prepare, it can be used in both block generation
 	// and verification. So determine the consensus rules by header type.
 	if !beacon.IsPoSHeader(header) {

--- a/consensus/clique/clique.go
+++ b/consensus/clique/clique.go
@@ -565,6 +565,12 @@ func (c *Clique) Prepare(chain consensus.ChainHeaderReader, header *types.Header
 // Finalize implements consensus.Engine, ensuring no uncles are set, nor block
 // rewards given.
 func (c *Clique) Finalize(chain consensus.ChainHeaderReader, header *types.Header, state *state.StateDB, txs []*types.Transaction, uncles []*types.Header) {
+	if chain.Config().IsBosagora(header.Number) {
+		if header.Number.Cmp(&chain.Config().Bosagora.LastCommonsBudgetRewardBlock) < 0 {
+			state.AddBalance(chain.Config().Bosagora.CommonsBudget, &chain.Config().Bosagora.CommonsBudgetReward)
+		}
+	}
+
 	header.Root = state.IntermediateRoot(chain.Config().IsEIP158(header.Number))
 	header.UncleHash = types.CalcUncleHash(nil)
 }

--- a/consensus/clique/clique.go
+++ b/consensus/clique/clique.go
@@ -565,12 +565,6 @@ func (c *Clique) Prepare(chain consensus.ChainHeaderReader, header *types.Header
 // Finalize implements consensus.Engine, ensuring no uncles are set, nor block
 // rewards given.
 func (c *Clique) Finalize(chain consensus.ChainHeaderReader, header *types.Header, state *state.StateDB, txs []*types.Transaction, uncles []*types.Header) {
-	if chain.Config().IsBosagora(header.Number) {
-		if header.Number.Cmp(&chain.Config().Bosagora.LastCommonsBudgetRewardBlock) < 0 {
-			state.AddBalance(chain.Config().Bosagora.CommonsBudget, &chain.Config().Bosagora.CommonsBudgetReward)
-		}
-	}
-
 	header.Root = state.IntermediateRoot(chain.Config().IsEIP158(header.Number))
 	header.UncleHash = types.CalcUncleHash(nil)
 }


### PR DESCRIPTION
I couldn't find the ability to process transactions in Agora-CL.
Therefore, I had to find a solution in Agora-EL.

The Commons Budget must be issued by Clique before The Merge and by Beacon after The Merge.

1. I added logging to confirm that the function Finalize is called several times to generate one block.

2. I checked that the consensus logic changes accurately when switching to POS using logging.

3. It was confirmed that the Merge was completed normally through 3 tests, and the issuance of Commons Budget was also carried out normally before and after that.
The two tests were a network using one CL node locally, and the other network settings were as follows.
https://github.com/zeroone-boa/agoranet/tree/v0.x.x/bellatrix
---

나는 Agora-CL에는 트랜잭션을 처리하는 기능을 찾을 수 없었다.
따라서 나는 해결책을 Agora-EL에서 찾아야 했다.
커먼스 버짓은 The Merge 전에는 Clique 발행되어야 하고, The Merge 후에는 Beacon 에서 발행되어야 한다.

1. 나는 로깅을 추가하여 함수 Finalize 가 하나의 블록을 생성하기 위해서 여러번 호출되는 것을 확인했다.

2. 나는 로깅을 이용하여 POS로 전환시 그 컨센서스 로직이 정확하게 변경되는 것을 확인했다.

3. 3개의 테스트를 통해서 병합이 정상적으로 완료되며,  그 전과 후에 커먼스 발행도 정상적으로 수행되는 것을 확인했다.
2개의 로컬에서 하나의 CL노드를 사용한 네트워크였고, 다른 하나의 네트워크 설정은 다음과 같다.
https://github.com/zeroone-boa/agoranet/tree/v0.x.x/bellatrix