### PR TITLE
Fix issue: Inconsistency Between State TransitionDB And FeeHistory

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -383,8 +383,7 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 		st.refundGas(params.RefundQuotientEIP3529)
 	}
 	effectiveTip := msg.GasPrice
-	// stop burning base fees if bosagora
-	if rules.IsLondon && !st.evm.ChainConfig().IsBosagora(st.evm.Context.BlockNumber) {
+	if rules.IsLondon {
 		effectiveTip = cmath.BigMin(msg.GasTipCap, new(big.Int).Sub(msg.GasFeeCap, st.evm.Context.BaseFee))
 	}
 


### PR DESCRIPTION
Description
Repository:

agora-el
Commit hash:

[b313d5358345f55bbc4e79b05904b5782227353f](https://github.com/bosagora/agora-el/tree/b313d5358345f55bbc4e79b05904b5782227353f)
Files:

agora-el/core/state_transition.go
In the TransitionDb method, when applying a specific message in the EVM to transition the state, a minor modification has been made to prevent the burning of the baseFee as per EIP1559.

func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {

	// stop burning base fees if bosagora
	if rules.IsLondon && !st.evm.ChainConfig().IsBosagora(st.evm.Context.BlockNumber) {
		effectiveTip = cmath.BigMin(msg.GasTipCap, new(big.Int).Sub(msg.GasFeeCap, st.evm.Context.BaseFee))
	}
However, in the FeeHistory API, the deducted baseFee result is still being used as the EffectiveGasTip for calculating the rewards.

func (tx *Transaction) EffectiveGasTip(baseFee *big.Int) (*big.Int, error) {
	if baseFee == nil {
		return tx.GasTipCap(), nil
	}
	var err error
	gasFeeCap := tx.GasFeeCap()
	if gasFeeCap.Cmp(baseFee) == -1 {
		err = ErrGasFeeCapTooLow
	}
	return math.BigMin(tx.GasTipCap(), gasFeeCap.Sub(gasFeeCap, baseFee)), err
}
This inconsistency between the state and the API may result in discrepancies for the surrounding applications downstream, potentially leading to unexpected errors.

Additionally, during the total fee calculation in the worker, the reliance on the EffectiveGasTip persists.

func totalFees(block *types.Block, receipts []*types.Receipt) *big.Int {
	feesWei := new(big.Int)
	for i, tx := range block.Transactions() {
		minerFee, _ := tx.EffectiveGasTip(block.BaseFee())
		feesWei.Add(feesWei, new(big.Int).Mul(new(big.Int).SetUint64(receipts[i].GasUsed), minerFee))
	}
	return feesWei
}
The resulting work and the corresponding logs could potentially hold different values compared to those executed in the state. This situation could introduce inconsistency among the nodes when attempting to calculate the exact fees within a single block.

Reference:

[EIP-1559](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1559.md)
Recommendation
Recommend revising the fee or reward calculation or design to make them consistent.